### PR TITLE
Set up filtering frontend

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -7,3 +7,4 @@ indexes:
     direction: desc
   - name: isApproved
   - name: moderatorList
+  

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,9 @@
+indexes:
+
+- kind: Distributor
+  ancestor: no
+  properties:
+  - name: creationTimeStampMillis
+    direction: desc
+  - name: isApproved
+  - name: moderatorList

--- a/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
@@ -48,18 +48,6 @@ public class ListOrganizationsServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     GivrUser currentUser = GivrUser.getLoggedInUser();
 
-    /* These statements show how to reference the parameters being received, for easier implementation of this backend */
-    if (request.getParameter("zipcode") != null) {
-      System.out.println("Zipcode is: " + request.getParameter("zipcode"));
-    }
-
-    if (request.getParameterValues("filterParam") != null) {
-      String filterParams[] = request.getParameterValues("filterParam");
-      for (String param : filterParams) {
-        System.out.println("One of the filter params is: " + param);
-      }
-    }
-
     /* All get requests will return a maximum of 5 organization entities */
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(5);
     Query query = getQueryFromParams(request, currentUser);

--- a/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
@@ -36,7 +36,6 @@ import com.google.sps.data.Organization;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.sps.data.GivrUser;
-import java.lang.*;
 import java.io.IOException;
 
 @WebServlet("/list-organizations")

--- a/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ListOrganizationsServlet.java
@@ -36,6 +36,7 @@ import com.google.sps.data.Organization;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.sps.data.GivrUser;
+import java.lang.*;
 import java.io.IOException;
 
 @WebServlet("/list-organizations")
@@ -48,9 +49,20 @@ public class ListOrganizationsServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     GivrUser currentUser = GivrUser.getLoggedInUser();
 
+    /* These statements show how to reference the parameters being received, for easier implementation of this backend */
+    if (request.getParameter("zipcode") != null) {
+      System.out.println("Zipcode is: " + request.getParameter("zipcode"));
+    }
+
+    if (request.getParameterValues("filterParam") != null) {
+      String filterParams[] = request.getParameterValues("filterParam");
+      for (String param : filterParams) {
+        System.out.println("One of the filter params is: " + param);
+      }
+    }
+
     /* All get requests will return a maximum of 5 organization entities */
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(5);
-
     Query query = getQueryFromParams(request, currentUser);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery prepQuery = datastore.prepare(query);
@@ -60,7 +72,6 @@ public class ListOrganizationsServlet extends HttpServlet {
 
     /* Fills requestedOrganizations array*/
     for (Entity entity : results) {
-      
       // TODO(): Implement better schema to represent opening and closing hours for different days
       Organization newOrg = new Organization(entity);
       requestedOrganizations.add(newOrg);
@@ -72,7 +83,7 @@ public class ListOrganizationsServlet extends HttpServlet {
 
   /* This function constructs a query based on the request parameters & user's role */
   public Query getQueryFromParams(HttpServletRequest request, GivrUser currentUser) {
-    Query query = new Query("Distributor").addSort("creationTimeStampMillis", SortDirection.DESCENDING);;
+    Query query = new Query("Distributor").addSort("creationTimeStampMillis", SortDirection.DESCENDING);
 
     /* displayUserOrgsParameter is true when user only wants to see orgs they moderate*/
     String displayUserOrgsParameter = request.getParameter("displayUserOrgs");
@@ -87,11 +98,10 @@ public class ListOrganizationsServlet extends HttpServlet {
       query.setFilter(new FilterPredicate("moderatorList", FilterOperator.EQUAL, userId));
     }
 
-    // TODO(): fix showing approved orgs
-    // if (!userIsMaintainer) {
-    //   /* If the user is not a maintainer, only allow them to see approved orgs */
-    //   query.setFilter(new FilterPredicate("isApproved", FilterOperator.EQUAL, true));
-    // }
+    if (!userIsMaintainer) {
+      /* If the user is not a maintainer, only allow them to see approved orgs */
+      query.setFilter(new FilterPredicate("isApproved", FilterOperator.EQUAL, true));
+    }
 
     // TODO(): Read through request parameters and for all valid parameters and use them to modify query (filtering)
 

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -68,7 +68,7 @@ class SearchArea {
     this.zipcodeSubmit = document.createElement("input");
     this.zipcodeSubmit.setAttribute("type", "submit");
     this.zipcodeSubmit.setAttribute("class", "gray-button");
-    this.zipcodeSubmit.addEventListener('click', () => this.handleZipcodeSubmission(this.form));
+    this.zipcodeSubmit.addEventListener('click', () => this.setUrlParamValue("zipcode", this.form.zipcode.value));
     this.form.appendChild(this.zipcodeSubmit);
 
     this.zipcodeFormArea.appendChild(this.form);
@@ -80,7 +80,7 @@ class SearchArea {
     this.filterInputArea.setAttribute("placeholder", "Filter Results");
     this.filterInputArea.addEventListener('keypress', function (e) {
       if (e.key === 'Enter') {
-        this.handleFilterSubmission(this.filterInputArea.value);
+        this.setUrlParamValue("filterParam", this.filterInputArea.value);
       }
     }.bind(this));
 
@@ -133,17 +133,13 @@ class SearchArea {
     });
   }
 
-  async handleZipcodeSubmission(zipcodeForm) {
-    this.filterParams.set("zipcode", zipcodeForm.zipcode.value);
-    this.organizationsObjectsList = [];
-    this.organizationListDiv.innerHTML = "";
-    this.organizationsObjectsList = await getListOfOrganizations(this.filterParams);
-    this.renderListOfOrganizations();
-  }
-
-  async handleFilterSubmission(filterParam) {
-    /* There can be more than one filterParam if the user clicks another without refreshing/clearing */
-    this.filterParams.append("filterParam", filterParam);
+  async setUrlParamValue(urlParamKey, urlParamValue) {
+    /* if the param is a zipcode, replace any existing one. Otherwise, add it to existing params */    
+    if (urlParamKey === "zipcode") {
+      this.filterParams.set(urlParamKey, urlParamValue);      
+    } else {
+      this.filterParams.append(urlParamKey, urlParamValue);      
+    }
     this.organizationsObjectsList = [];
     this.organizationListDiv.innerHTML = "";
     this.organizationsObjectsList = await getListOfOrganizations(this.filterParams);

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -44,7 +44,7 @@ class SearchArea {
   constructor(searchAreaElement, organizations, isMaintainer) {
     this.searchArea = searchAreaElement;
     this.organizationSearchArea = document.createElement("div");
-    this.organizationsObjectsList = organizations;
+    this.organizationObjectsList = organizations;
     this.isMaintainer = isMaintainer;
     this.filterParams = new URLSearchParams();
 
@@ -96,8 +96,8 @@ class SearchArea {
     this.filterInputArea.appendChild(this.filterDataList);
     this.organizationSearchArea.appendChild(this.filterInputArea);
 
-    this.organizationListDiv = document.createElement("div");
-    this.organizationListDiv.setAttribute("id", "organization-list");
+    this.organizationListArea = document.createElement("div");
+    this.organizationListArea.setAttribute("id", "organization-list");
     
     this.organizationPopupArea = document.createElement("div");
     this.organizationPopupArea.setAttribute("id", "organization-popup-area");
@@ -105,13 +105,13 @@ class SearchArea {
 
     this.renderListOfOrganizations();
 
-    this.organizationSearchArea.appendChild(this.organizationListDiv);
+    this.organizationSearchArea.appendChild(this.organizationListArea);
     this.searchArea.appendChild(this.organizationSearchArea);
     this.searchArea.appendChild(this.organizationPopupArea);
   }
 
   async renderListOfOrganizations() {
-    this.organizationsObjectsList.forEach((organization) => {
+    this.organizationObjectsList.forEach((organization) => {
       const newOrganization = new Organization(organization, this.isMaintainer);
 
       newOrganization.organizationElement.addEventListener('organization-selected', () => {
@@ -129,7 +129,7 @@ class SearchArea {
         newOrganization.popupElement.remove();
       });
 
-      this.organizationListDiv.appendChild(newOrganization.getOrganization());
+      this.organizationListArea.appendChild(newOrganization.getOrganization());
     });
   }
 
@@ -140,9 +140,9 @@ class SearchArea {
     } else {
       this.filterParams.append(urlParamKey, urlParamValue);      
     }
-    this.organizationsObjectsList = [];
-    this.organizationListDiv.innerHTML = "";
-    this.organizationsObjectsList = await getListOfOrganizations(this.filterParams);
+    this.organizationObjectsList = [];
+    this.organizationListArea.innerHTML = "";
+    this.organizationObjectsList = await getListOfOrganizations(this.filterParams);
     this.renderListOfOrganizations();
   }
 }

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -21,13 +21,13 @@ document.addEventListener("DOMContentLoaded", async function() {
   if (document.getElementById('search-area')) {
     const mainSearchArea = new SearchArea(document.getElementById('search-area'), isMaintainer);
     await mainSearchArea.getListOfOrganizations();
-    await mainSearchArea.renderListOfOrganizations()
+    mainSearchArea.renderListOfOrganizations()
   }
   isMaintainer = true;
   if (document.getElementById('all-organizations')) {
     const organizationSearchArea = new SearchArea(document.getElementById('all-organizations'), isMaintainer);
     await organizationSearchArea.getListOfOrganizations();
-    await organizationSearchArea.renderListOfOrganizations();
+    organizationSearchArea.renderListOfOrganizations();
   }
 });
 
@@ -69,18 +69,18 @@ class SearchArea {
     this.filterInputArea.setAttribute("list", "filter-datalist");
     this.filterInputArea.setAttribute("id", "filter-input-area");
     this.filterInputArea.setAttribute("placeholder", "Filter Results");
-    this.filterInputArea.addEventListener('keypress', function (e) {
+    this.filterInputArea.addEventListener('keypress', (e) => {
       if (e.key === 'Enter') {
         this.setUrlParamValue("filterParam", this.filterInputArea.value);
       }
-    }.bind(this));
+    });
 
     this.filterDataList = document.createElement("datalist");
     this.filterDataList.setAttribute("id", "filter-datalist");
     this.filterOptions = ["Foods", "Clothing", "Shelter"];
-    for (let i = 0; i < this.filterOptions.length; i++) {
+    for (const value of this.filterOptions) {
       const option = document.createElement("option");
-      option.value = this.filterOptions[i];
+      option.value = value;
       this.filterDataList.appendChild(option);
     }
 
@@ -99,7 +99,7 @@ class SearchArea {
     this.searchArea.appendChild(this.organizationPopupArea);
   }
 
-  async renderListOfOrganizations() {
+  renderListOfOrganizations() {
     this.organizationObjectsList.forEach((organization) => {
       const newOrganization = new Organization(organization, this.isMaintainer);
 
@@ -142,6 +142,6 @@ class SearchArea {
     this.organizationObjectsList = [];
     this.organizationListArea.innerHTML = "";
     await this.getListOfOrganizations();
-    await this.renderListOfOrganizations();
+    this.renderListOfOrganizations();
   }
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -58,7 +58,7 @@
   font-size: 20px;
 }
 
-#filter-button-area {
+#filter-input-area {
   margin: 3% auto;
   height: 30px;
 }
@@ -76,7 +76,7 @@
   padding: 5px 20px;
 }
 
-#filter-button {
+#filter-datalist {
     float: right;
 }
 


### PR DESCRIPTION
This PR adds frontend functionality to the "enter zipcode" section and replaces the "filter" button with a datalist element
Here is the current appearance of this frontend: 
![image](https://user-images.githubusercontent.com/54298330/87177695-0efe5800-c2aa-11ea-95e3-11e1479e3d6a.png)

****This functionality sends the parameters to the backend correctly formatted, but the backend does not modify the query with those parameters yet***

Current user flow/abilities: 
-The user can enter a zipcode and hit enter, this adds that zipcode to the urlsearchparams and calls getListOfOrganizations with that zipcode added. If the user wants to enter another zipcode, the previous one they added will still be in that text field, so they will need to backspace it and hit enter again. This new 5 digit sequence will replace the old zipcode in the urlsearchparams.

-The user can either type their own, or select one of the suggested filtering keywords from the datalist dropdown. After the user is satisfied with the word in the datalist textfield, they must hit enter to send the request. **Important difference from the zipcode functionality:** : After hitting enter on a filter keyword in the datastore, the user CAN enter another keyword and the previous filtering keyword will NOT be overwritten. They will be sent as an array, and to see how this array is referenced on the backend look at line 57 of ListOrg servlet. The urlsearchparams can contain a single zipcode and any amount of strings with "filterParam" keys 

I intentionally left the print statements in the list org servlet so there is no confusion on how to access these url parameters.

Remaining TODOs for frontend filtering:
-Display all current active filters being applied to the query for the user to see on the frontend
-Allow the user to selectively remove filters from the urlsearchparams after adding them
-Add debouncing protection to the enter buttons / text field