### PR TITLE
Improve filtering frontend

### DIFF
--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -41,7 +41,6 @@ class SearchArea {
     this.forOrganizationsPage = forOrganizationsPage;
     this.filterParams = new URLSearchParams();
     this.organizationObjectsList = [];
-    this.filterTagsList = [];
 
     this.zipcodeFormArea = document.createElement("div");
     this.form = document.createElement("form");

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -199,7 +199,7 @@ class SearchArea {
     if (urlParamKey === "zipcode") {
       this.filterParams.delete("zipcode");
     } else {
-      if (this.filterParams.getAll("filterParam").length === 0) {
+      if (this.filterParams.getAll("filterParam").length === 1) {
         /* If only 1 filter param, delete the array */
         this.filterParams.delete("filterParam");
       } else {

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -147,7 +147,6 @@ class SearchArea {
   }
 
   async setUrlParamValue(urlParamKey, urlParamValue) {   
-    
     /* New query value is not added if it is a duplicate or empty/null */
     if (this.filterParams.getAll("filterParam").includes(urlParamValue) ||
         this.filterParams.getAll("zipcode").includes(urlParamValue) ||
@@ -196,7 +195,6 @@ class SearchArea {
   }
 
   async removeFilterTag(urlParamKey, urlParamValue, filterTag) {
-
     if (urlParamKey === "zipcode") {
       this.filterParams.delete("zipcode");
     } else {

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -41,6 +41,7 @@ class SearchArea {
     this.forOrganizationsPage = forOrganizationsPage;
     this.filterParams = new URLSearchParams();
     this.organizationObjectsList = [];
+    this.filterTagsList = [];
 
     this.zipcodeFormArea = document.createElement("div");
     this.form = document.createElement("form");
@@ -75,6 +76,7 @@ class SearchArea {
     this.filterInputArea.addEventListener('keypress', (e) => {
       if (e.key === 'Enter') {
         this.setUrlParamValue("filterParam", this.filterInputArea.value);
+        this.filterInputArea.value = "";
       }
     });
 
@@ -89,6 +91,10 @@ class SearchArea {
 
     this.filterInputArea.appendChild(this.filterDataList);
     this.organizationSearchArea.appendChild(this.filterInputArea);
+
+    this.activeFilterArea = document.createElement("div");
+    this.activeFilterArea.setAttribute("class", "filter-holder"); //REMOVE THIS LINE
+    this.organizationSearchArea.appendChild(this.activeFilterArea);
 
     this.organizationListArea = document.createElement("div");
     this.organizationListArea.setAttribute("id", "organization-list");
@@ -135,13 +141,71 @@ class SearchArea {
     this.organizationObjectsList = await response.json();
   }
 
-  async setUrlParamValue(urlParamKey, urlParamValue) {
-    /* if the param is a zipcode, replace any existing one. Otherwise, add it to existing params */    
+  async setUrlParamValue(urlParamKey, urlParamValue) {   
+    
+    /* New query value is not added if it is a duplicate or empty/null */
+    if (this.filterParams.getAll("filterParam").includes(urlParamValue) ||
+        this.filterParams.getAll("zipcode").includes(urlParamValue) ||
+        (urlParamValue === null) || (urlParamValue.trim() === "")) {
+      return;
+    }
+    
+    /* if the param is a zipcode, remove tag of any existing one & set new one*/ 
     if (urlParamKey === "zipcode") {
+      if (this.filterParams.get("zipcode")) {
+        /* If there is a zipcode being displayed, remove its tag so both aren't displayed */
+        this.removeFilterTag("zipcode", this.filterParams.get("zipcode"), document.getElementById("zipcodeTag"));
+      }
       this.filterParams.set(urlParamKey, urlParamValue);      
     } else {
       this.filterParams.append(urlParamKey, urlParamValue);      
     }
+    this.form.reset();
+    this.addFilterTag(urlParamKey, urlParamValue);
+    this.organizationObjectsList = [];
+    this.organizationListArea.innerHTML = "";
+    await this.getListOfOrganizations();
+    this.renderListOfOrganizations();
+  }
+
+  addFilterTag(urlParamKey, urlParamValue) {
+    let filterTagArea = document.createElement("div");
+    filterTagArea.setAttribute("class", "filter-tag-area");
+    /* ID is given to zipcode tag so it can be removed if new one is added */
+    if (urlParamKey === "zipcode") {
+      filterTagArea.setAttribute("id", "zipcodeTag");
+    }
+
+    let filterTagLabel = document.createElement("div");
+    filterTagLabel.textContent = urlParamValue;
+    filterTagLabel.setAttribute("class", "filter-tag-label");
+    filterTagArea.appendChild(filterTagLabel);
+
+    let filterTagClose = document.createElement("div");
+    filterTagClose.addEventListener('click', () => this.removeFilterTag(urlParamKey, urlParamValue, filterTagArea));
+    filterTagClose.textContent = 'X';
+    filterTagClose.setAttribute("class", "filter-tag-close");
+    filterTagArea.appendChild(filterTagClose);
+
+    this.activeFilterArea.appendChild(filterTagArea);
+  }
+
+  async removeFilterTag(urlParamKey, urlParamValue, filterTag) {
+
+    if (urlParamKey === "zipcode") {
+      this.filterParams.delete("zipcode");
+    } else {
+      if (this.filterParams.getAll("filterParam").length === 0) {
+        /* If only 1 filter param, delete the array */
+        this.filterParams.delete("filterParam");
+      } else {
+        /* If not, just remove specified element */
+        let filterArray = this.filterParams.getAll("filterParam");
+        filterArray.splice(filterArray.indexOf(urlParamValue), 1);
+        this.filterParams.set("filterParam", filterArray);
+      }
+    }
+    this.activeFilterArea.removeChild(filterTag);
     this.organizationObjectsList = [];
     this.organizationListArea.innerHTML = "";
     await this.getListOfOrganizations();

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -93,7 +93,7 @@ class SearchArea {
     this.organizationSearchArea.appendChild(this.filterInputArea);
 
     this.activeFilterArea = document.createElement("div");
-    this.activeFilterArea.setAttribute("class", "filter-holder"); //REMOVE THIS LINE
+    this.activeFilterArea.setAttribute("class", "filter-holder");
     this.organizationSearchArea.appendChild(this.activeFilterArea);
 
     this.organizationListArea = document.createElement("div");

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -74,6 +74,7 @@ class SearchArea {
     this.filterInputArea.setAttribute("placeholder", "Filter Results");
     this.filterInputArea.addEventListener('keypress', (e) => {
       if (e.key === 'Enter') {
+        /* When the user hits enter in the filter input area, it is added as a param */
         this.setUrlParamValue("filterParam", this.filterInputArea.value);
         this.filterInputArea.value = "";
       }

--- a/src/main/webapp/search_area.js
+++ b/src/main/webapp/search_area.js
@@ -129,6 +129,12 @@ class SearchArea {
 
       this.organizationListArea.appendChild(newOrganization.getOrganization());
     });
+    if (this.organizationObjectsList.length === 0) {
+      const noResultsFoundMessage = document.createElement("div");
+      noResultsFoundMessage.setAttribute("id", "no-results-found");
+      noResultsFoundMessage.textContent = "No results found for current filters.";
+      this.organizationListArea.appendChild(noResultsFoundMessage);
+    }
   }
 
   async getListOfOrganizations() {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -196,3 +196,37 @@
   border: 1px solid #888;
   width: 70%;
 }
+
+.filter-holder {
+  overflow: hidden;
+  padding-bottom: 10px;
+}
+
+.filter-tag-area {
+  display: flex;
+  justify-content: space-around;
+  border: 3px solid purple;
+  background-color: rgba(158, 52, 235, 0.80);
+  border-radius: 10px;
+  resize: horizontal;
+  float:left;
+  white-space: nowrap;
+  margin-left: 10px;
+  padding: 5px 20px;
+}
+
+.filter-tag-label {
+  font-family:'Courier New', Courier, monospace;
+  color: hsl(64, 100%, 88%);
+  font-size: 15px;
+}
+
+.filter-tag-close {
+  cursor:pointer;
+  font-size: 10px;
+  float:right;
+  color: rgb(255, 254, 254);
+  padding: 2px;
+  border: 2px solid #ccc;
+  border-radius: 50%
+}

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -217,7 +217,7 @@
 
 .filter-tag-label {
   font-family:'Courier New', Courier, monospace;
-  color: hsl(61, 97%, 88%);
+  color: rgb(18, 16, 13);
   font-size: 15px;
 }
 
@@ -225,7 +225,7 @@
   cursor:pointer;
   font-size: 10px;
   float:right;
-  color: rgb(255, 254, 254);
+  color: rgb(18, 16, 13);
   padding: 2px;
   border: 2px solid #ccc;
   border-radius: 50%

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -205,8 +205,8 @@
 .filter-tag-area {
   display: flex;
   justify-content: space-around;
-  border: 3px solid purple;
-  background-color: rgba(158, 52, 235, 0.80);
+  border: 3px solid rgb(121, 121, 121);
+  background-color: rgba(216, 216, 216, 0.8);
   border-radius: 10px;
   resize: horizontal;
   float:left;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -217,7 +217,7 @@
 
 .filter-tag-label {
   font-family:'Courier New', Courier, monospace;
-  color: hsl(64, 100%, 88%);
+  color: hsl(61, 97%, 88%);
   font-size: 15px;
 }
 
@@ -230,3 +230,11 @@
   border: 2px solid #ccc;
   border-radius: 50%
 }
+
+#no-results-found {
+  display: flex;
+  justify-content: center;
+  color: rgb(109, 101, 101);
+  font-size: 20px;
+}
+


### PR DESCRIPTION
This addresses the issues in #46  

Here is a photo of what this looks like (working form is currently deployed)

![image](https://user-images.githubusercontent.com/54298330/87472170-82c39c00-c5ed-11ea-9ec5-e140f96348ad.png)

-Displays all current active filters being applied to the query for the user to see on the frontend
-Allow the user to selectively remove filters from the urlsearchparams after adding them
-Add debouncing protection to the enter buttons / text field
    Right now, it just clears out the input box and requires the user to click it again and type something to enter another request. 
     This delay combined with the awaits seems to protect enough, possible todo is to add more protection in future

![image](https://user-images.githubusercontent.com/54298330/87473884-30d04580-c5f0-11ea-80e6-2054acc89220.png)
