### PR TITLE
Fix semantics of resource listing

### DIFF
--- a/src/main/java/com/google/sps/data/OrganizationUpdater.java
+++ b/src/main/java/com/google/sps/data/OrganizationUpdater.java
@@ -59,7 +59,7 @@ public final class OrganizationUpdater {
     properties.put("org-description","orgDescription");
     properties.put("approval", "isApproved");
     properties.put("moderator-list", "moderatorList");
-    properties.put("org-resource-category", "resourceCategories");
+    properties.put("org-resource-categories", "resourceCategories");
 
     // Updates entity properties from form
     for(Map.Entry<String, String> entry : properties.entrySet()) {
@@ -124,8 +124,7 @@ public final class OrganizationUpdater {
           this.entity.setProperty("isApproved", false);
       }
     } else if (propertyKey.equals("resourceCategories")) {
-      ArrayList<String> resourceList = new ArrayList<String>();
-      resourceList.add(formValue);
+      ArrayList<String> resourceList = new ArrayList<String>(Arrays.asList(formValue.split("\\s*,\\s*")));
       this.entity.setProperty("resourceCategories", resourceList);
     } else {
         this.entity.setProperty(propertyKey, formValue);

--- a/src/main/webapp/organization.js
+++ b/src/main/webapp/organization.js
@@ -253,18 +253,19 @@ class Organization {
 
     // label and entry area for organization resource category list
     const orgResourceCategoryListLabel = document.createElement("label");
-    orgResourceCategoryListLabel.setAttribute("for", "org-resource-category");
+    orgResourceCategoryListLabel.setAttribute("for", "org-resource-categories");
     orgResourceCategoryListLabel.setAttribute("id", "resource-category-list-label");
     orgResourceCategoryListLabel.textContent = "Resource Categories: ";
     editForm.appendChild(orgResourceCategoryListLabel);
 
-    const orgResourceCategory = document.createElement("textarea");
-    orgResourceCategory.setAttribute("type", "text");
-    orgResourceCategory.setAttribute("id", "org-resource-category");
-    orgResourceCategory.setAttribute("name", "org-resource-category");
-    orgResourceCategory.classList.add("edit-entry");
-    orgResourceCategory.textContent = JSON.stringify(organization.resourceCategories);
-    editForm.appendChild(orgResourceCategory);
+    const orgResourceCategories = document.createElement("textarea");
+    orgResourceCategories.setAttribute("type", "text");
+    orgResourceCategories.setAttribute("id", "org-resource-categories");
+    orgResourceCategories.setAttribute("name", "org-resource-categories");
+    orgResourceCategories.classList.add("edit-entry");
+    const resourceArray = organization.resourceCategories;
+    orgResourceCategories.textContent = resourceArray.join(",  ");
+    editForm.appendChild(orgResourceCategories);
 
     // label and entry area for organization moderator list
     const orgModeratorListLabel = document.createElement("label");


### PR DESCRIPTION
Changed the listing on the resources to be from a JSON stringify to a comma delimited array, and changes category to categories, since it should be plural


old: https://screenshot.googleplex.com/niW4ZdmgvKD


new: 
![image](https://user-images.githubusercontent.com/54298330/88232353-b5037800-cc43-11ea-8b6f-46ee9711e9ae.png)


