### PR TITLE
Fix retrieval of isModerator status in OrganizationUpdater

### DIFF
--- a/src/main/java/com/google/sps/data/OrganizationUpdater.java
+++ b/src/main/java/com/google/sps/data/OrganizationUpdater.java
@@ -56,7 +56,11 @@ public final class OrganizationUpdater {
     Set<String> requiresModerator = new HashSet<String>();
     Map<String, String> properties = new HashMap<String,String>();
     boolean isMaintainer = user.isMaintainer();
-    boolean isModerator = user.isModeratorOfAnyOrg();
+    boolean isModerator = false;
+    if (!forRegistration) {
+      // Organization entity's ID will exist after it has been created.
+      isModerator = user.isModeratorOfOrgWithId(this.entity.getKey().getId());
+    }
 
     requiresMaintainer.add("isApproved");
     requiresModerator.add("moderatorList");


### PR DESCRIPTION
This PR accomplishes retrieving the user's moderator status based on GivrUser's isModeratorOfOrgWithId(long orgId). Before this change, the isModerator status of the user was being set true even if the user was not a moderator of the specific org that is being updated.