### PR TITLE
Fix bug in GivrUser where id is ""

### DIFF
--- a/src/main/java/com/google/sps/data/GivrUser.java
+++ b/src/main/java/com/google/sps/data/GivrUser.java
@@ -130,6 +130,7 @@ public class GivrUser {
 
     for (Map.Entry<String, Object> entry: updatePropertyNamesAndValues.entrySet()) {
       entity.setProperty(entry.getKey(), entry.getValue());
+      System.out.println("key: " + entry.getKey() + " value: " + entry.getValue());
     }
     datastore.put(entity);
   }

--- a/src/main/java/com/google/sps/data/GivrUser.java
+++ b/src/main/java/com/google/sps/data/GivrUser.java
@@ -168,10 +168,10 @@ public class GivrUser {
     Entity entityRetrievedWithId = null;
     Entity entityRetrievedWithEmail = null;
 
-    if (userId != null) {
+    if (userId != null && !userId.equals("")) {
       entityRetrievedWithId = getUserFromDatastoreWithProperty("userId", userId);
     }
-    if (userEmail != null) {
+    if (userEmail != null && !userEmail.equals("")) {
       entityRetrievedWithEmail = getUserFromDatastoreWithProperty("userEmail", userEmail);
     }
 
@@ -180,10 +180,12 @@ public class GivrUser {
 
     if (entityRetrievedWithId != null) {
       isMaintainer = (boolean) entityRetrievedWithId.getProperty("isMaintainer");
-      userEmail = (String) entityRetrievedWithId.getProperty("userEmail");
+      String email = (String) entityRetrievedWithId.getProperty("userEmail");
+      userEmail = email.equals("") ? userEmail : email;
     } else if (entityRetrievedWithEmail != null) {
       isMaintainer = (boolean) entityRetrievedWithEmail.getProperty("isMaintainer");
-      userId = (String) entityRetrievedWithEmail.getProperty("userId");
+      String id = (String) entityRetrievedWithEmail.getProperty("userId");
+      userId = id.equals("") ? userId : id;
     }
     
     GivrUser user = new GivrUser(userId, isMaintainer, isLoggedIn, "" /* URL is not needed when User is logged in. */, userEmail);
@@ -206,6 +208,7 @@ public class GivrUser {
     String url = "";
     
     if (isUserLoggedIn) {
+
       return getUserByIdOrEmail(userService.getCurrentUser().getUserId(), userService.getCurrentUser().getEmail());
     }
     url = userService.createLoginURL("/");

--- a/src/main/java/com/google/sps/data/GivrUser.java
+++ b/src/main/java/com/google/sps/data/GivrUser.java
@@ -130,7 +130,6 @@ public class GivrUser {
 
     for (Map.Entry<String, Object> entry: updatePropertyNamesAndValues.entrySet()) {
       entity.setProperty(entry.getKey(), entry.getValue());
-      System.out.println("key: " + entry.getKey() + " value: " + entry.getValue());
     }
     datastore.put(entity);
   }

--- a/src/main/java/com/google/sps/servlets/AuthenticateServlet.java
+++ b/src/main/java/com/google/sps/servlets/AuthenticateServlet.java
@@ -49,13 +49,6 @@ public class AuthenticateServlet extends HttpServlet {
 
     Entity userWithEmail = GivrUser.getUserFromDatastoreWithProperty("userEmail", user.getUserEmail());
       if (userWithEmail != null) {
-        // User is either a Moderator or Maintainer, that has not logged in.
-        boolean isMaintainer = user.isMaintainer();
-        if (!isMaintainer) { // User is a Moderator.
-
-          // TODO: Update organization.
-        }
-
         // Update entity with current user's userId.
         propertyNamesAndValuesToUpdate.put("userId", user.getUserId());
         GivrUser.updateUserInDatastore("userEmail", user.getUserEmail(), propertyNamesAndValuesToUpdate);

--- a/src/test/java/com/google/sps/GivrUserTest.java
+++ b/src/test/java/com/google/sps/GivrUserTest.java
@@ -201,6 +201,7 @@ public final class GivrUserTest {
       throw new Error("GivrUserTest - authenticateUpdateUsersIdwithEmailWhenUserLogsInTest has failed.");
     }
 
+    // Now our Datastore has the updated User2 ID, so the actualUser result should not be null.
     GivrUser actualUser = GivrUser.getUserById("User2");
     GivrUser expectedUser = new GivrUser("User2", false, true, "", "jennb206+test2@gmail.com");
     Assert.assertEquals(expectedUser, actualUser);


### PR DESCRIPTION
After refactoring, the userId was overridden with "" value, so any Maintainer or Moderator's userIDs were not being updated correctly in the Datastore.