### PR TITLE
More tests

### DIFF
--- a/src/main/java/com/google/sps/data/ListEventsHelper.java
+++ b/src/main/java/com/google/sps/data/ListEventsHelper.java
@@ -53,12 +53,15 @@ public class ListEventsHelper extends ListHelper {
    * see organizations or events they belong to */
   public ArrayList<Filter> handleUserFiltering(boolean displayForUser) {
     ArrayList<Filter> filterCollection = new ArrayList<Filter>();
-    if (displayForUser) {
+    if (displayForUser && (!this.currentUser.isMaintainer())) {
       ArrayList<Entity> moderatingOrgs = this.currentUser.getModeratingOrgs();
 
       ArrayList<Long> moderatingOrgIds = new ArrayList<Long>();
       for (Entity entity : moderatingOrgs) {
         moderatingOrgIds.add(entity.getKey().getId());
+      }
+      if (moderatingOrgIds.size() == 0) {
+        moderatingOrgIds.add(new Long(-1)); // arraylist needs a value to work, -1 ensures nothing is returned
       }
       filterCollection.add(new FilterPredicate("ownerOrgId", FilterOperator.IN, moderatingOrgIds));
     }

--- a/src/test/java/com/google/sps/ListEventServletTest.java
+++ b/src/test/java/com/google/sps/ListEventServletTest.java
@@ -188,9 +188,6 @@ public final class ListEventServletTest {
     Assert.assertArrayEquals(expectedList.toArray(), datastore.prepare(receivedQuery).asList(fetchOptions).toArray());
   }
 
-  // TODO: add a test for when the user is a Maintainer, when the user is a moderator of an org with
-  // no events, and when the user is not a moderator
-
   @Test
   public void testEventQueryForMaintainer() {
   /* Tests makes sure that a maintainer will see all events in the "Show My Events" tab*/
@@ -200,7 +197,7 @@ public final class ListEventServletTest {
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     when(mockRequest.getParameter("displayForUser")).thenReturn("true");
 
-    /* Expected list only contains the events hosted by orgs 4, 5, or 6 in zipcode 02763 w/ address 10 Main st. */
+    /* Expected list contains all events since this user is a maintainer */
     ArrayList<Entity> expectedList = new ArrayList<Entity>();
     expectedList.add(masterEntityList.get(6));
     expectedList.add(masterEntityList.get(5));
@@ -223,7 +220,7 @@ public final class ListEventServletTest {
     GivrUser mockUser = mock(GivrUser.class);
     
     ArrayList<Entity> moderatingOrgs = new ArrayList<Entity>();
-    /* This user moderates the orgs w/ ID 20, which does not have any events */
+    /* This user moderates the org w/ ID 20, which does not have any events */
     moderatingOrgs.add(new Entity("Distributor", 20));
     when(mockUser.getModeratingOrgs()).thenReturn(moderatingOrgs);
 

--- a/src/test/java/com/google/sps/ListEventServletTest.java
+++ b/src/test/java/com/google/sps/ListEventServletTest.java
@@ -60,7 +60,7 @@ public final class ListEventServletTest {
     helper.setUp();
     //                                Existing entity table
     // +-------+-------------------------+------------------+---------+---------------+
-    // | Index | creationTimeStampMillis | ownerOrgId  | zipCode | streetAddress |
+    // | Index | creationTimeStampMillis | ownerOrgId       | zipCode | streetAddress |
     // +-------+-------------------------+------------------+---------+---------------+
     // |     0 |                       0 | 1                |   12345 | 12 Oak st.    |
     // |     1 |                       1 | 3                |   02763 | 12 Oak st.    |
@@ -190,4 +190,76 @@ public final class ListEventServletTest {
 
   // TODO: add a test for when the user is a Maintainer, when the user is a moderator of an org with
   // no events, and when the user is not a moderator
+
+  @Test
+  public void testEventQueryForMaintainer() {
+  /* Tests makes sure that a maintainer will see all events in the "Show My Events" tab*/
+    GivrUser mockUser = mock(GivrUser.class);
+    when(mockUser.isMaintainer()).thenReturn(true);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    when(mockRequest.getParameter("displayForUser")).thenReturn("true");
+
+    /* Expected list only contains the events hosted by orgs 4, 5, or 6 in zipcode 02763 w/ address 10 Main st. */
+    ArrayList<Entity> expectedList = new ArrayList<Entity>();
+    expectedList.add(masterEntityList.get(6));
+    expectedList.add(masterEntityList.get(5));
+    expectedList.add(masterEntityList.get(4));
+    expectedList.add(masterEntityList.get(3));
+    expectedList.add(masterEntityList.get(2));
+    expectedList.add(masterEntityList.get(1));
+    expectedList.add(masterEntityList.get(0));
+ 
+    ListEventsHelper listEventsHelper = new ListEventsHelper("Event", mockRequest, mockUser);
+    Query receivedQuery = listEventsHelper.getQuery();
+
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(10);
+    Assert.assertArrayEquals(expectedList.toArray(), datastore.prepare(receivedQuery).asList(fetchOptions).toArray());
+  }
+
+  @Test
+  public void testEventQueryForOrgWithoutEvents() {
+    /* Tests to make sure correct query is returned when user is a moderator of an org with no events*/
+    GivrUser mockUser = mock(GivrUser.class);
+    
+    ArrayList<Entity> moderatingOrgs = new ArrayList<Entity>();
+    /* This user moderates the orgs w/ ID 20, which does not have any events */
+    moderatingOrgs.add(new Entity("Distributor", 20));
+    when(mockUser.getModeratingOrgs()).thenReturn(moderatingOrgs);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    when(mockRequest.getParameter("displayForUser")).thenReturn("true");
+
+    /* Expected list is empty because this user's moderating org has no events*/
+    ArrayList<Entity> expectedList = new ArrayList<Entity>();
+ 
+    ListEventsHelper listEventsHelper = new ListEventsHelper("Event", mockRequest, mockUser);
+    Query receivedQuery = listEventsHelper.getQuery();
+
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(10);
+    Assert.assertArrayEquals(expectedList.toArray(), datastore.prepare(receivedQuery).asList(fetchOptions).toArray());
+  }
+
+  @Test
+  public void testEventQueryForNonModerator() {
+    /* Tests to make sure no results are returned when displayForUser = true, but user is not moderator */
+    GivrUser mockUser = mock(GivrUser.class);
+    when(mockUser.isMaintainer()).thenReturn(false);
+
+    ArrayList<Entity> moderatingOrgs = new ArrayList<Entity>();
+    /* This user does not moderate any organizations */
+    when(mockUser.getModeratingOrgs()).thenReturn(moderatingOrgs);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    when(mockRequest.getParameter("displayForUser")).thenReturn("true");
+
+    /* Expected list is empty */
+    ArrayList<Entity> expectedList = new ArrayList<Entity>();
+ 
+    ListEventsHelper listEventsHelper = new ListEventsHelper("Event", mockRequest, mockUser);
+    Query receivedQuery = listEventsHelper.getQuery();
+
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(10);
+    Assert.assertArrayEquals(expectedList.toArray(), datastore.prepare(receivedQuery).asList(fetchOptions).toArray());
+  }
 }


### PR DESCRIPTION
Adds tests for ListEventHelper for when the user is a Maintainer, when the user is a moderator of an org with no events, and when the user is not a moderator. Also fixes bug on ListEventHelper to remove error that happens when moderator id list is an empty collection
